### PR TITLE
Fix up some out-of-date includes

### DIFF
--- a/control.c
+++ b/control.c
@@ -35,6 +35,7 @@
 #include "filtering.h"
 #ifndef __NO_EVENTS__
 #include <linux/iio/events.h>
+#include <linux/iio/types.h>
 #endif
 #include <errno.h>
 

--- a/utils.c
+++ b/utils.c
@@ -20,7 +20,6 @@
 #include <utils/Log.h>
 #include <hardware/sensors.h>
 #include <utils/Atomic.h>
-#include <linux/android_alarm.h>
 
 #include "common.h"
 #include "utils.h"


### PR DESCRIPTION
IIO_EV_DIR_FALLING is now enumerated in linux/iio/types.h, and
linux/android_alarm.h no longer exists.

Signed-off-by: Jeff LaBundy <jeff@labundy.com>